### PR TITLE
Correct #rand to return nil when set is empty

### DIFF
--- a/lib/multiset.rb
+++ b/lib/multiset.rb
@@ -690,6 +690,7 @@ class Multiset
   # Returns one item in <code>self</code> randomly.
   # All items are selected with the same probability.
   def sample
+    return nil if empty?
     pos = Kernel.rand(self.size)
     @entries.each_pair do |item, count|
       pos -= count

--- a/spec/multiset_spec.rb
+++ b/spec/multiset_spec.rb
@@ -230,7 +230,11 @@ describe Multiset do
     it "should return a new Multiset by the specified condition with Multiset#map_with / Multiset#collect_with" do
       @ms.map_with{ |item, count| [item * 2, count * 2] }.should == Multiset.new(%w'aa aa aa aa bb bb bb bb bb bb bb bb cc cc dd dd dd dd dd dd')
     end
-    
+
+    it "should return nil for an empty Multiset with Multiset#rand" do
+      Multiset.new.rand.should == nil
+    end
+
     it "should return the maximum/mininum value by max/min/minmax" do
       @ms.max.should == "d"
       @ms.min.should == "a"


### PR DESCRIPTION
Hi, I'm not sure if the current behavior of `Multiset#rand` while empty is intended, but it seemed like a bug to me. This changes the behavior to return `nil` if the set is empty, mirror `Array#rand` with an empty array.

Before:

``` ruby
>> Multiset.new.rand
=> {}
```

After:

``` ruby
>> Multiset.new.rand
=> nil
```
